### PR TITLE
Log document task errors to stdout to help with debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.4
+
+- Log errors during document tasks to stdout
+
 ## v1.0.3
 
 - Fix `timeless!` being ignored

--- a/lib/hekenga/version.rb
+++ b/lib/hekenga/version.rb
@@ -1,3 +1,3 @@
 module Hekenga
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
It'd be nice to have them in a Hekenga::Failure::Error; but without extra refactoring this would cancel the running task

Just log them to stdout for now so at least we can retrieve them from somewhere