### PR TITLE
watch/failures CLI commands + skip_validation!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v2.2.0
+
+- Added a `hekenga watch <path_or_pkey>` CLI command to attach to a running
+    migration and report its status periodically. Accepts an `--interval`
+    option (defaults to `Hekenga.config.report_sleep`).
+- Added a `hekenga failures <path_or_pkey>` CLI command to print all failed and
+    invalid document IDs across a migration's document tasks.
+- Document tasks now support a `skip_validation!` option to write documents
+    without running `.valid?`.
+
 ## v2.1.0
 
 - `per_document` task `scope` will no longer let you specify `.only` or

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ $ hekenga run! <path_or_pkey>           # Run a specific migration
 $ hekenga run! <path_or_pkey> --test    # Dry run (no writes persisted)
 $ hekenga run! <path_or_pkey> --clear   # Clear logs before running
 $ hekenga recover! <path_or_pkey>       # Re-process failed/invalid records
+$ hekenga watch <path_or_pkey>          # Attach to a running migration, report status periodically
+$ hekenga failures <path_or_pkey>       # Print all failed/invalid document IDs for a migration
 $ hekenga cancel                        # Cancel all active migrations
 $ hekenga skip <path_or_pkey>           # Mark a migration as skipped
 $ hekenga clear! <path_or_pkey>         # Remove all logs/failures for a migration
@@ -118,6 +120,7 @@ per_document "Process records" do
   timeless!                           # Don't update Mongoid timestamps
   always_write!                       # Write even if the document didn't change
   skip_prepare!                       # Skip Mongoid callbacks on load
+  skip_validation!                    # Write documents without running Mongoid validations
   use_transaction!                    # Wrap each batch in a MongoDB transaction
   batch_size 50                       # Override migration-level batch size
   write_strategy :update              # :update (default) or :delete_then_insert
@@ -143,11 +146,24 @@ Or via the CLI:
 
     $ hekenga run! <path_or_pkey> --test
 
+### Monitoring
+
+Attach to a migration that's already running (for example one launched in another process or via a background job) and print its status on a fixed interval:
+
+    $ hekenga watch <path_or_pkey>
+    $ hekenga watch <path_or_pkey> --interval 5   # report every 5 seconds
+
+The reporting interval defaults to `Hekenga.config.report_sleep`.
+
 ### Recovery
 
 When a migration fails (due to errors, invalid records, or write failures), Hekenga logs the failures and marks the migration as failed. You can re-process only the failed records:
 
     $ hekenga recover! <path_or_pkey>
+
+To inspect exactly which documents failed or were invalid across all document tasks in a migration:
+
+    $ hekenga failures <path_or_pkey>
 
 ## Development
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,22 +9,41 @@ networks:
 services:
   mongo:
     image: mongo:6
-    command: ["--replSet", "rs0", "--bind_ip", "localhost,mongo"]
+    command: ["--replSet", "rs0", "--bind_ip_all"]
     volumes:
       - mongo:/data/db
     ports:
       - 27017:27017
     networks:
       - hekenga-net
+    healthcheck:
+      # mongo:6 ships mongosh (the legacy `mongo` shell was removed in 6.0).
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
 
   mongosetup:
     image: mongo:6
     depends_on:
-      - mongo
+      mongo:
+        condition: service_healthy
     restart: "no"
     entrypoint:
-      - bash
-      - "-c"
-      - "sleep 3 && mongo --host mongo:27017 --eval 'rs.initiate({_id: \"rs0\", members: [{_id: 0, host: \"localhost:27017\"}]})'"
+      - mongosh
+      - "--quiet"
+      - "--host"
+      - "mongo:27017"
+      - "--eval"
+      # Idempotent: initiate the single-member replica set only if it hasn't
+      # been configured yet, so re-running compose doesn't error. The member
+      # advertises as localhost:27017 so the driver on the host can reach it
+      # after replica-set topology discovery (required for transactions).
+      - >
+        try { rs.status(); print('replica set already initialised'); }
+        catch (e) {
+          rs.initiate({_id: 'rs0', members: [{_id: 0, host: 'localhost:27017'}]});
+          print('replica set initiated');
+        }
     networks:
       - hekenga-net

--- a/exe/hekenga
+++ b/exe/hekenga
@@ -71,6 +71,14 @@ class HekengaCLI < Thor
     end
   end
 
+  desc "watch PATH_OR_PKEY", "Attach to a running migration and report its status periodically."
+  option :interval, type: :numeric, desc: "Seconds between status reports (default: Hekenga.config.report_sleep)."
+  def watch(path_or_pkey)
+    migration = load_migration(path_or_pkey)
+    interval  = options[:interval] || Hekenga.config.report_sleep
+    Hekenga::MasterProcess.new(migration).watch!(interval: interval)
+  end
+
   desc "cancel", "Cancel all active migrations."
   def cancel
     Hekenga::Log.where(done: false).set(cancel: true)

--- a/exe/hekenga
+++ b/exe/hekenga
@@ -79,6 +79,12 @@ class HekengaCLI < Thor
     Hekenga::MasterProcess.new(migration).watch!(interval: interval)
   end
 
+  desc "failures PATH_OR_PKEY", "Print all failed and invalid document IDs for a migration."
+  def failures(path_or_pkey)
+    migration = load_migration(path_or_pkey)
+    Hekenga::FailureReport.new(migration).print!
+  end
+
   desc "cancel", "Cancel all active migrations."
   def cancel
     Hekenga::Log.where(done: false).set(cancel: true)

--- a/lib/hekenga.rb
+++ b/lib/hekenga.rb
@@ -6,6 +6,7 @@ require "hekenga/config"
 require "hekenga/irreversible"
 require "hekenga/virtual_method"
 require "hekenga/scaffold"
+require "hekenga/failure_report"
 
 module Hekenga
   @@load_all_mutex = Mutex.new

--- a/lib/hekenga/document_task.rb
+++ b/lib/hekenga/document_task.rb
@@ -5,7 +5,7 @@ module Hekenga
     attr_reader :ups, :downs, :setups, :filters, :after_callbacks
     attr_accessor :parallel, :scope, :timeless, :batch_size, :cursor_timeout
     attr_accessor :description, :invalid_strategy, :skip_prepare, :write_strategy
-    attr_accessor :always_write, :use_transaction
+    attr_accessor :always_write, :use_transaction, :skip_validation
 
     def initialize
       @ups              = []
@@ -16,6 +16,7 @@ module Hekenga
       @invalid_strategy = :continue
       @write_strategy   = :update
       @skip_prepare     = false
+      @skip_validation  = false
       @batch_size       = nil
       @always_write     = false
       @use_transaction  = false

--- a/lib/hekenga/document_task_executor.rb
+++ b/lib/hekenga/document_task_executor.rb
@@ -116,6 +116,8 @@ module Hekenga
     end
 
     def validate_records
+      return records_to_write.concat(migrated_records) if task.skip_validation
+
       migrated_records.each do |record|
         if record.valid?
           records_to_write << record

--- a/lib/hekenga/dsl/document_task.rb
+++ b/lib/hekenga/dsl/document_task.rb
@@ -56,6 +56,10 @@ module Hekenga
         @object.skip_prepare = true
       end
 
+      def skip_validation!
+        @object.skip_validation = true
+      end
+
       def setup(&block)
         @object.setups.push block
       end

--- a/lib/hekenga/failure_report.rb
+++ b/lib/hekenga/failure_report.rb
@@ -1,0 +1,60 @@
+module Hekenga
+  class FailureReport
+    def initialize(migration)
+      @migration = migration
+    end
+
+    # Per-task summaries for document tasks that have any failed or invalid
+    # document IDs.
+    # => [{ idx:, description:, failed_ids: [...], invalid_ids: [...] }, ...]
+    def tasks
+      @migration.tasks.each.with_index.filter_map do |task, idx|
+        next unless task.is_a?(Hekenga::DocumentTask)
+
+        records = @migration.task_records(idx).any_of(
+          { :failed_ids.ne  => [] },
+          { :invalid_ids.ne => [] }
+        )
+
+        failed_ids  = []
+        invalid_ids = []
+        records.pluck(:failed_ids, :invalid_ids).each do |failed, invalid|
+          failed_ids.concat(failed)   if failed
+          invalid_ids.concat(invalid) if invalid
+        end
+        next if failed_ids.empty? && invalid_ids.empty?
+
+        {
+          idx:         idx,
+          description: task.description,
+          failed_ids:  failed_ids,
+          invalid_ids: invalid_ids
+        }
+      end
+    end
+
+    def print!
+      Hekenga.log("Failures for #{@migration.to_key}")
+
+      summaries = tasks
+      if summaries.empty?
+        Hekenga.log("  No failed or invalid documents.")
+        return
+      end
+
+      failed_ids  = summaries.flat_map { |summary| summary[:failed_ids] }
+      invalid_ids = summaries.flat_map { |summary| summary[:invalid_ids] }
+
+      print_ids("Failed",  failed_ids)
+      print_ids("Invalid", invalid_ids)
+    end
+
+    private
+
+    def print_ids(label, ids)
+      return if ids.empty?
+
+      Hekenga.log("    #{label} (#{ids.length}): #{ids.map { |id| "\"#{id}\"" }.join(", ")}")
+    end
+  end
+end

--- a/lib/hekenga/master_process.rb
+++ b/lib/hekenga/master_process.rb
@@ -33,18 +33,35 @@ module Hekenga
       true
     end
 
+    def watch!(interval: Hekenga.config.report_sleep)
+      if Hekenga.status(@migration) == :naught
+        Hekenga.log "Migration #{@migration.to_key} has not started yet."
+        return false
+      end
+      Hekenga.log "Watching migration #{@migration.to_key}: #{@migration.description}"
+      @migration.tasks.each.with_index do |task, idx|
+        report_while_active(task, idx, interval: interval)
+      rescue Hekenga::TaskFailedError
+        return false
+      end
+      true
+    end
+
     private
 
-    def report_while_active(task, idx)
-      # Wait for the log to be generated
+    def report_while_active(task, idx, interval: Hekenga.config.report_sleep)
+      # Wait for the log to be generated. When watching an out-of-process
+      # migration there is no @active_thread guaranteeing it, so bail out if
+      # the migration finished without ever reaching this task.
       until (@migration.log(idx) rescue nil)
+        return if %i[complete skipped].include?(Hekenga.status(@migration))
         sleep 1
       end
-      # Periodically report on thread progress
+      # Periodically report on progress
       until @migration.log(idx).reload.done
-        @active_thread.join
+        @active_thread&.join
         report_status(task, idx)
-        sleep Hekenga.config.report_sleep
+        sleep interval
       end
       report_status(task, idx) if task.is_a?(Hekenga::DocumentTask)
       report_result(task, idx)

--- a/lib/hekenga/version.rb
+++ b/lib/hekenga/version.rb
@@ -1,3 +1,3 @@
 module Hekenga
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/spec/hekenga/document_task_spec.rb
+++ b/spec/hekenga/document_task_spec.rb
@@ -115,6 +115,49 @@ describe Hekenga::DocumentTask do
     end
   end
 
+  describe "skip_validation!" do
+    let(:migration) do
+      Hekenga.migration do
+        description "Skip validation"
+        created "2024-07-02 10:00"
+
+        per_document "Demo" do
+          scope Example.all
+          skip_validation!
+
+          up do |doc|
+            doc.num = 100
+          end
+        end
+      end
+    end
+
+    it "sets skip_validation on the task" do
+      expect(migration.tasks[0].skip_validation).to eq(true)
+    end
+
+    it "writes records that would otherwise be invalid" do
+      migration.perform!
+      expect(Example.pluck(:num)).to eq([100, 100, 100])
+      records = migration.task_records(0)
+      expect(records.map(&:invalid_ids).flatten).to be_empty
+      expect(records.map(&:written_ids).flatten.length).to eq(3)
+    end
+
+    it "defaults to false" do
+      other = Hekenga.migration do
+        description "No skip validation"
+        created "2024-07-02 10:05"
+
+        per_document "Demo" do
+          scope Example.all
+          up { |doc| doc.num += 1 }
+        end
+      end
+      expect(other.tasks[0].skip_validation).to eq(false)
+    end
+  end
+
   describe "setup block accepting docs" do
     let(:migration) do
       Hekenga.migration do

--- a/spec/hekenga/failures_cli_spec.rb
+++ b/spec/hekenga/failures_cli_spec.rb
@@ -1,0 +1,125 @@
+require 'spec_helper'
+
+describe "Reporting migration failures" do
+  before(:each) do
+    5.times.each do |idx|
+      Example.create! string: "idx-#{idx}", num: idx
+    end
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  describe "a doc task with an error on up" do
+    let(:migration) do
+      Hekenga.migration do
+        description "Failing report"
+        created "2024-07-02 10:00"
+        batch_size 1
+
+        per_document "break" do
+          scope Example.all
+          up do |doc|
+            raise "Problem" if doc.num >= 3
+          end
+        end
+      end
+    end
+
+    let(:failed_docs) { Example.where(:num.gte => 3).to_a }
+
+    before do
+      capture_stdout { migration.perform! }
+    end
+
+    it "reports the failed document IDs via #tasks" do
+      summaries = Hekenga::FailureReport.new(migration).tasks
+      expect(summaries.length).to eq(1)
+      expect(summaries.first[:idx]).to eq(0)
+      expect(summaries.first[:failed_ids]).to match_array(failed_docs.map(&:id))
+      expect(summaries.first[:invalid_ids]).to be_empty
+    end
+
+    it "prints the failed document IDs" do
+      output = capture_stdout do
+        Hekenga::FailureReport.new(migration).print!
+      end
+      expect(output).to include(migration.to_key)
+      expect(output).to include("Failed (#{failed_docs.length})")
+      failed_docs.each do |doc|
+        expect(output).to include("\"#{doc.id}\"")
+      end
+    end
+  end
+
+  describe "a doc task that produces an invalid document" do
+    let(:migration) do
+      Hekenga.migration do
+        description "Invalid report"
+        created "2024-07-02 11:00"
+        batch_size 1
+
+        per_document "break" do
+          scope Example.all
+          up do |doc|
+            doc.num = 100 if doc.num >= 3
+          end
+        end
+      end
+    end
+
+    let(:invalid_docs) { Example.where(:num.gte => 3).to_a }
+
+    before do
+      capture_stdout { migration.perform! }
+    end
+
+    it "reports the invalid document IDs" do
+      summaries = Hekenga::FailureReport.new(migration).tasks
+      expect(summaries.first[:invalid_ids]).to match_array(invalid_docs.map(&:id))
+
+      output = capture_stdout do
+        Hekenga::FailureReport.new(migration).print!
+      end
+      expect(output).to include("Invalid (#{invalid_docs.length})")
+      invalid_docs.each do |doc|
+        expect(output).to include("\"#{doc.id}\"")
+      end
+    end
+  end
+
+  describe "a clean migration" do
+    let(:migration) do
+      Hekenga.migration do
+        description "Clean report"
+        created "2024-07-02 13:00"
+
+        per_document "noop" do
+          scope Example.all
+          up do |doc|
+            doc.num += 1
+          end
+        end
+      end
+    end
+
+    before do
+      capture_stdout { migration.perform! }
+    end
+
+    it "reports that there are no failed or invalid documents" do
+      expect(Hekenga::FailureReport.new(migration).tasks).to be_empty
+
+      output = capture_stdout do
+        Hekenga::FailureReport.new(migration).print!
+      end
+      expect(output).to include("No failed or invalid documents.")
+    end
+  end
+end

--- a/spec/hekenga/watch_spec.rb
+++ b/spec/hekenga/watch_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe "Watching a migration" do
+  before(:each) do
+    3.times.each do |idx|
+      Example.create! string: "idx-#{idx}", num: idx
+    end
+  end
+
+  let(:migration) do
+    Hekenga.migration do
+      description "Watchable migration"
+      created "2024-07-02 09:00"
+
+      per_document "Demo" do
+        scope Example.all
+        up do |doc|
+          doc.num += 1
+        end
+      end
+    end
+  end
+
+  def capture_stdout
+    original = $stdout
+    $stdout = StringIO.new
+    yield
+    $stdout.string
+  ensure
+    $stdout = original
+  end
+
+  describe "a migration that has not started" do
+    it "reports that it hasn't started and returns false" do
+      result = nil
+      output = capture_stdout do
+        result = Hekenga::MasterProcess.new(migration).watch!(interval: 0)
+      end
+      expect(result).to eq(false)
+      expect(output).to include("has not started yet")
+    end
+  end
+
+  describe "a migration that has completed" do
+    before(:each) { migration.perform! }
+
+    it "reports the final result and returns true" do
+      result = nil
+      output = capture_stdout do
+        result = Hekenga::MasterProcess.new(migration).watch!(interval: 0)
+      end
+      expect(result).to eq(true)
+      expect(output).to include("Watching migration #{migration.to_key}")
+      expect(output).to include("Migration result:")
+      expect(output).to include("Written: 3")
+      expect(output).to include("Completed")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,17 @@ Dir["#{MODELS}/*.rb"].each {|f| require f}
 Dir[File.join(File.dirname(__FILE__), "support", "*.rb")].each {|f| require f}
 
 Mongoid.configure do |config|
-  config.connect_to "hekenga_test"
+  config.clients.default = {
+    hosts: [ENV.fetch("MONGO_HOST", "localhost:27017")],
+    database: "hekenga_test",
+    options: {
+      # The test cluster (see docker-compose.yml) is a single-member replica
+      # set advertising itself as "localhost:27017". We must let the driver
+      # perform replica-set topology discovery (i.e. NOT set direct_connection)
+      # so that Cluster#replica_set? is true and transactions are permitted.
+      replica_set: "rs0"
+    }
+  }
   config.logger = nil
 end
 Hekenga.configure do |config|

--- a/spec/support/active_job_assertions.rb
+++ b/spec/support/active_job_assertions.rb
@@ -1,0 +1,21 @@
+# ActiveJob's test helpers (e.g. perform_enqueued_jobs) wrap the yielded block
+# in ActiveSupport::Testing::Assertions#assert_nothing_raised. That method is
+# written for a Minitest runtime: it calls `assert(true)` on success and wraps
+# any error in Minitest::UnexpectedError. Under RSpec neither `assert` nor the
+# Minitest constant exist, so the helper blows up (masking the real error).
+#
+# Rather than loading Minitest just to satisfy those references, we override
+# the single offending method to run the block and let genuine errors surface
+# naturally. Requiring the helper first guarantees the original definition is
+# in place before we reopen the module.
+require "active_job/test_helper"
+
+module ActiveSupport
+  module Testing
+    module Assertions
+      def assert_nothing_raised
+        yield
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes

### `hekenga watch <path_or_pkey>`
Attach to a migration that's already running (e.g. one launched in another process or via a background job) and report its status on a fixed interval.
Accepts `--interval`  (defaults to `Hekenga.config.report_sleep`).

### `hekenga failures <path_or_pkey>`
Print all failed and invalid document IDs across a migration's document tasks, making it easy to inspect exactly what went wrong before recovering.

### `skip_validation!` document-task option
Document tasks can now write documents without running `.valid?`, for cases where validation is unnecessary or intentionally bypassed.

### Housekeeping
- Bumped version to `2.2.0` and updated `CHANGELOG.md` / `README.md`.
- Fixed the test environment (`docker-compose.yml`, spec helper, added
  ActiveJob assertion helpers).

## Testing
- Added specs: `spec/hekenga/watch_spec.rb`,  `spec/hekenga/failures_cli_spec.rb`, and `skip_validation!` coverage in `spec/hekenga/document_task_spec.rb`.
- `rake spec`